### PR TITLE
add invoice and invoice_item record endpoints

### DIFF
--- a/app/controllers/api/v1/invoice_items_controller.rb
+++ b/app/controllers/api/v1/invoice_items_controller.rb
@@ -1,2 +1,9 @@
 class Api::V1::InvoiceItemsController < ApplicationController
+  def index
+    render json: InvoiceItem.all
+  end
+
+  def show
+    render json: InvoiceItem.find(params[:id])
+  end
 end

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -1,2 +1,9 @@
 class Api::V1::InvoicesController < ApplicationController
+  def index
+    render json: Invoice.all
+  end
+
+  def show
+    render json: Invoice.find(params[:id])
+  end
 end

--- a/spec/factories/invoice_items.rb
+++ b/spec/factories/invoice_items.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :invoice_item do
     quantity 1
     unit_price "9.99"
-    item nil
-    invoice nil
+    item
+    invoice
   end
 end

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :invoice do
     status "MyString"
-    customer nil
-    merchant nil
+    customer
+    merchant
   end
 end

--- a/spec/requests/api/v1/invoice_items_request_spec.rb
+++ b/spec/requests/api/v1/invoice_items_request_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe "InvoiceItems API" do
+  it "sends a list of invoice_items" do
+     create_list(:invoice_item, 3)
+
+      get '/api/v1/invoice_items'
+
+      expect(response).to be_success
+
+      invoice_items = JSON.parse(response.body)
+   end
+
+   it "can get one invoice_item by its id" do
+    id = create(:invoice_item).id
+
+    get "/api/v1/invoice_items/#{id}"
+
+    invoice_item = JSON.parse(response.body)
+
+    expect(response).to be_success
+    expect(invoice_item["id"]).to eq(id)
+  end
+end

--- a/spec/requests/api/v1/invoices_request_spec.rb
+++ b/spec/requests/api/v1/invoices_request_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe "Invoices API" do
+  it "sends a list of invoices" do
+     create_list(:invoice, 3)
+
+      get '/api/v1/invoices'
+
+      expect(response).to be_success
+
+      invoices = JSON.parse(response.body)
+   end
+
+   it "can get one invoice by its id" do
+    id = create(:invoice).id
+
+    get "/api/v1/invoices/#{id}"
+
+    invoice = JSON.parse(response.body)
+
+    expect(response).to be_success
+    expect(invoice["id"]).to eq(id)
+  end
+end


### PR DESCRIPTION
Adds record endpoints for invoice and invoice items. This still needs to be verified with the spec harness.