### PR TITLE
adds relationship endpoints for merchants

### DIFF
--- a/app/controllers/api/v1/merchants/invoices_controller.rb
+++ b/app/controllers/api/v1/merchants/invoices_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Merchants::InvoicesController < ApplicationController
+  def index
+    render json: Merchant.find(params["merchant_id"]).invoices
+  end
+end

--- a/app/controllers/api/v1/merchants/items_controller.rb
+++ b/app/controllers/api/v1/merchants/items_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Merchants::ItemsController < ApplicationController
+  def index
+    render json: Merchant.find(params["merchant_id"]).items
+  end
+end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -160,13 +160,47 @@ describe "Merchants API" do
       create_list(:merchant, 3)
 
       get '/api/v1/merchants/random'
-      
+
       merchant = JSON.parse(response.body)
 
       expect(response).to be_success
       expect(merchant).to be_a(Hash)
       expect(merchant).to have_key("id")
       expect(merchant).to have_key("name")
+    end
+  end
+
+  context "relationship methods" do
+    it "can find all the items for a merchant" do
+      merchant = create(:merchant)
+      items = create_list(:item, 2, merchant: merchant)
+      create_list(:item, 3)
+
+      get "/api/v1/merchants/#{merchant.id}/items"
+
+      results = JSON.parse(response.body)
+
+      expect(response).to be_success
+      expect(results.count).to eq(2)
+
+      expect(results.first["id"]).to eq(items.first.id)
+      expect(results.second["id"]).to eq(items.second.id)
+    end
+
+    it "can find all the invoices for a merchant" do
+      merchant = create(:merchant)
+      invoices = create_list(:invoice, 2, merchant: merchant)
+      create_list(:invoice, 3)
+
+      get "/api/v1/merchants/#{merchant.id}/invoices"
+
+      results = JSON.parse(response.body)
+
+      expect(response).to be_success
+      expect(results.count).to eq(2)
+
+      expect(results.first["id"]).to eq(invoices.first.id)
+      expect(results.second["id"]).to eq(invoices.second.id)
     end
   end
 


### PR DESCRIPTION
Adds relationship endpoints for merchant/items and merchant/invoices so you can load a collection of items or invoices associated with a merchant.
-adds 'items' and 'invoices' controllers for merchants
-all tests and spec harness passing